### PR TITLE
Add new keywords for Readline 7.0 / Bash 4.4

### DIFF
--- a/syntax/readline.vim
+++ b/syntax/readline.vim
@@ -111,7 +111,7 @@ syn keyword readlineKeyword     contained
                               \ nextgroup=readlineVariable
                               \ skipwhite
 
-syn keyword readlineVariable    contained 
+syn keyword readlineVariable    contained
                               \ nextgroup=readlineBellStyle
                               \ skipwhite
                               \ bell-style
@@ -120,12 +120,15 @@ syn keyword readlineVariable    contained
                               \ nextgroup=readlineBoolean
                               \ skipwhite
                               \ bind-tty-special-chars
+                              \ blink-matching-paren
+                              \ colored-completion-prefix
                               \ colored-stats
                               \ completion-ignore-case
                               \ completion-map-case
                               \ convert-meta
                               \ disable-completion
                               \ echo-control-characters
+                              \ enable-bracketed-paste
                               \ enable-keypad
                               \ enable-meta-key
                               \ expand-tilde
@@ -269,6 +272,7 @@ syn keyword readlineFunction    contained
                               \ start-kbd-macro
                               \ end-kbd-macro
                               \ call-last-kbd-macro
+                              \ print-last-kbd-macro
                               \
                               \ re-read-init-file
                               \ abort
@@ -339,6 +343,8 @@ syn keyword readlineFunction    contained
 
 if exists("readline_has_bash")
   syn keyword readlineFunction  contained
+                              \ shell-forward-word
+                              \ shell-backward-word
                               \ shell-expand-line
                               \ history-expand-line
                               \ magic-space
@@ -347,6 +353,8 @@ if exists("readline_has_bash")
                               \ insert-last-argument
                               \ operate-and-get-next
                               \ forward-backward-delete-char
+                              \ shell-kill-word
+                              \ shell-backward-kill-word
                               \ delete-char-or-list
                               \ complete-filename
                               \ possible-filename-completions
@@ -359,6 +367,7 @@ if exists("readline_has_bash")
                               \ complete-command
                               \ possible-command-completions
                               \ dynamic-complete-history
+                              \ dabbrev-expand
                               \ complete-into-braces
                               \ glob-expand-word
                               \ glob-list-expansions


### PR DESCRIPTION
I noticed that the latest keywords were missing for readline syntax highlighting in vim, so I added them. They appear in the same order as in the Bash man page, as do the existing ones as far as I can tell, and keywords that are Bash specific are properly in the section for `readline_has_bash`.

There is also a whitespace change (removal of a trailing blank).